### PR TITLE
Contain images that don't match a 9/16 aspect-ratio with object-fit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ function css(duration: number) {
     max-width: 100%;
     width: 100%;
     aspect-ratio: 9/16;
+    object-fit: contain;
     top: 0;
     opacity: 0;
   }


### PR DESCRIPTION
Currently, if an image does not fit a `9/16` aspect ratio they appear stretched:

<img width="486" alt="Screenshot 2023-08-07 at 10 40 41 PM" src="https://github.com/dddddddddzzzz/open-stories-element/assets/10888441/5c840860-4489-4cf8-94df-8dc5a50c9e5e">

Other platforms which have stories contain the asset, causing black bars above and below the image so the assets don't appear warped. With this change, assets that are not `9/16` will look more reasonable.

<img width="513" alt="Screenshot 2023-08-07 at 10 37 13 PM" src="https://github.com/dddddddddzzzz/open-stories-element/assets/10888441/39803b1c-863b-4d05-b952-6f5e283c63ef">

This change has no effect on existing users who already comply with the `9/16` guidelines (example below on @muan's page)

<img width="883" alt="Screenshot 2023-08-07 at 10 42 17 PM" src="https://github.com/dddddddddzzzz/open-stories-element/assets/10888441/708c258e-f5a4-42f1-b6fb-615a6fb69362">

