### PR TITLE
fix: 🐛 Cannot set property src of #<OpenStoriesElement> which has only a getter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -417,7 +417,7 @@ class OpenStoriesElement extends HTMLElement {
   open: boolean = false
   goToBinding: () => void
   items: OpenStoriesFeed["items"] = []
-	_src: URL | null
+	_src: string
 	_duration: number
 
   constructor() {
@@ -530,7 +530,7 @@ class OpenStoriesElement extends HTMLElement {
       this.button.click()
     })
 
-    const src = this.src?.toString()
+    const src = this.src
     if (src) this.fetchData(src)
 
     const style = document.createElement('style')
@@ -546,10 +546,10 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   set src(path: string) {
-    this._src = new URL(path || "", location.href);
+    this._src = new URL(path || "", location.href).toString()
   }
 
-  get src(): URL | null {
+  get src(): string {
     return this._src;
   }
 
@@ -847,7 +847,7 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   get viewedKey() {
-    return this.src?.toString()
+    return this.src
   }
 
   get lazyLoad() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -417,6 +417,8 @@ class OpenStoriesElement extends HTMLElement {
   open: boolean = false
   goToBinding: () => void
   items: OpenStoriesFeed["items"] = []
+	_src: URL | null
+	_duration: number
 
   constructor() {
     super()
@@ -483,6 +485,9 @@ class OpenStoriesElement extends HTMLElement {
     this.link = this.root.querySelector('a#link')!
     this.time = this.root.querySelector('#time')!
     this.goToBinding = this.goTo.bind(this, 1)
+		
+		this._src = ""
+		this._duration = 5
   }
 
   get isHighlight() {
@@ -525,7 +530,7 @@ class OpenStoriesElement extends HTMLElement {
       this.button.click()
     })
 
-    const src = this.getAttribute('src')
+    const src = this.src?.toString()
     if (src) this.fetchData(src)
 
     const style = document.createElement('style')
@@ -540,12 +545,20 @@ class OpenStoriesElement extends HTMLElement {
     })
   }
 
-  get src() {
-    return this.hasAttribute('src') ? new URL(this.getAttribute('src') || '', location.href) : ''
+  set src(path: string) {
+    this._src = new URL(path || "", location.href);
   }
 
-  get duration() {
-    return this.hasAttribute('duration') ? Number(this.getAttribute('duration')) : 5
+  get src(): URL | null {
+    return this._src;
+  }
+
+  set duration(value: number) {
+    this._duration = Number(value) || 5;
+  }
+
+  get duration(): number {
+    return this._duration;
   }
 
   async sendHeart() {
@@ -834,7 +847,7 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   get viewedKey() {
-    return new URL(this.getAttribute('src')!, location.origin).toString()
+    return this.src?.toString()
   }
 
   get lazyLoad() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -486,13 +486,13 @@ class OpenStoriesElement extends HTMLElement {
     this.time = this.root.querySelector('#time')!
     this.goToBinding = this.goTo.bind(this, 1)
 		
-    this._src = this.hasAttribute("src")
-      ? this.formatSrc(this.getAttribute("src"))
-      : "";
+    this._src = this.hasAttribute('src')
+      ? this.formatSrc(this.getAttribute('src'))
+      : ''
 
-    this._duration = this.hasAttribute("duration")
-      ? Number(this.getAttribute("duration"))
-      : 5;
+    this._duration = this.hasAttribute('duration')
+      ? Number(this.getAttribute('duration'))
+      : 5
   }
 
   get isHighlight() {
@@ -551,19 +551,19 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   set src(path: string) {
-    this._src = this.formatSrc(path);
+    this._src = this.formatSrc(path)
   }
 
   get src(): string {
-    return this._src;
+    return this._src
   }
 
   set duration(value: number) {
-    this._duration = Number(value);
+    this._duration = Number(value)
   }
 
   get duration(): number {
-    return this._duration;
+    return this._duration
   }
 
   async sendHeart() {
@@ -720,7 +720,7 @@ class OpenStoriesElement extends HTMLElement {
    * @returns - The formatted path.
    */
   formatSrc(path: string | null): string {
-    return new URL(path || "", location.href).toString()
+    return new URL(path || '', location.href).toString()
   }
 
   setIndexToUnread() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -486,8 +486,13 @@ class OpenStoriesElement extends HTMLElement {
     this.time = this.root.querySelector('#time')!
     this.goToBinding = this.goTo.bind(this, 1)
 		
-		this._src = ""
-		this._duration = 5
+    this._src = this.hasAttribute("src")
+      ? this.formatSrc(this.getAttribute("src"))
+      : "";
+
+    this._duration = this.hasAttribute("duration")
+      ? Number(this.getAttribute("duration"))
+      : 5;
   }
 
   get isHighlight() {
@@ -546,7 +551,7 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   set src(path: string) {
-    this._src = new URL(path || "", location.href).toString()
+    this._src = this.formatSrc(path);
   }
 
   get src(): string {
@@ -554,7 +559,7 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   set duration(value: number) {
-    this._duration = Number(value) || 5;
+    this._duration = Number(value);
   }
 
   get duration(): number {
@@ -707,6 +712,15 @@ class OpenStoriesElement extends HTMLElement {
     window.addEventListener('hashchange', this.checkHashId.bind(this))
     if (this.checkHashId()) return
     this.setIndexToUnread()
+  }
+
+  /**
+   * Format a path to a valid URL. 
+   * @param path - The path to format.
+   * @returns - The formatted path.
+   */
+  formatSrc(path: string | null): string {
+    return new URL(path || "", location.href).toString()
   }
 
   setIndexToUnread() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -551,6 +551,7 @@ class OpenStoriesElement extends HTMLElement {
   }
 
   set src(path: string) {
+    this.setAttribute('src', path)
     this._src = this.formatSrc(path)
   }
 


### PR DESCRIPTION
Related: https://github.com/dddddddddzzzz/OpenStories/issues/10

I kept running into the following error intermittently, I thought it was because I was providing `src` incorrectly but it appears I was wrong. Because of the type of error being thrown here, in certain frameworks such as Next.js it prevents the whole page from rendering.

```
TypeError: Cannot set property src of #<OpenStoriesElement> which has only a getter
```

From my understanding of this error, this is due to the usage of the `get` keyword without an accompanying `set` keyword. In this pull request, I've refactored `src` and `duration` so they implement `set`  which resolves the error for me.

I've validated the best I can but would appreciate it if you pulled this down locally to test everything out too (if you wish to merge this that is) as you all know the ins and outs of this better than I do 😄 

